### PR TITLE
feat: enable light and dark themes

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,6 +6,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import Home from "@/pages/home";
 import BlogPost from "@/pages/blog-post";
 import NotFound from "@/pages/not-found";
+import { ThemeProvider } from "@/components/theme-provider";
 
 function Router() {
   return (
@@ -19,12 +20,14 @@ function Router() {
 
 function App() {
   return (
-    <QueryClientProvider client={queryClient}>
-      <TooltipProvider>
-        <Toaster />
-        <Router />
-      </TooltipProvider>
-    </QueryClientProvider>
+    <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <Toaster />
+          <Router />
+        </TooltipProvider>
+      </QueryClientProvider>
+    </ThemeProvider>
   );
 }
 

--- a/client/src/components/layout/footer.tsx
+++ b/client/src/components/layout/footer.tsx
@@ -1,9 +1,9 @@
 export default function Footer() {
   return (
-    <footer className="bg-slate-800 text-white py-12">
+    <footer className="bg-muted text-muted-foreground py-12">
       <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center">
-          <p className="text-slate-300">
+          <p className="text-muted-foreground">
             © 2025 Matthew Tang. Built with React and passion for clean code.
           </p>
         </div>

--- a/client/src/components/layout/navigation.tsx
+++ b/client/src/components/layout/navigation.tsx
@@ -3,6 +3,7 @@ import { Link } from "wouter";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { Menu, Github, Linkedin, Mail } from "lucide-react";
+import { ModeToggle } from "@/components/mode-toggle";
 
 export default function Navigation() {
   const [isOpen, setIsOpen] = useState(false);
@@ -32,12 +33,12 @@ export default function Navigation() {
   };
 
   return (
-    <nav className="sticky top-0 bg-white/80 backdrop-blur-md border-b border-slate-200 z-50">
+    <nav className="sticky top-0 bg-background/80 backdrop-blur-md border-b border-border z-50">
       <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           <div className="flex items-center">
             <Link href="/">
-              <span className="text-xl font-semibold text-slate-800 hover:text-blue-600 transition-colors">
+              <span className="text-xl font-semibold text-foreground hover:text-primary transition-colors">
                 Matthew
               </span>
             </Link>
@@ -49,7 +50,7 @@ export default function Navigation() {
               <button
                 key={link.href}
                 onClick={() => handleNavClick(link.href)}
-                className="text-slate-600 hover:text-blue-600 transition-colors font-medium"
+                className="text-muted-foreground hover:text-primary transition-colors font-medium"
               >
                 {link.label}
               </button>
@@ -57,17 +58,18 @@ export default function Navigation() {
           </div>
 
           {/* Social Links */}
-          <div className="hidden md:flex space-x-3">
+          <div className="hidden md:flex items-center space-x-3">
+            <ModeToggle />
             {socialLinks.map((social) => (
               <a
                 key={social.label}
                 href={social.href}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="w-8 h-8 bg-slate-100 hover:bg-slate-200 rounded-full flex items-center justify-center transition-colors"
+                className="w-8 h-8 bg-muted hover:bg-muted/80 rounded-full flex items-center justify-center transition-colors"
                 aria-label={social.label}
               >
-                <social.icon className="w-4 h-4 text-slate-600" />
+                <social.icon className="w-4 h-4 text-muted-foreground" />
               </a>
             ))}
           </div>
@@ -86,22 +88,25 @@ export default function Navigation() {
                     <button
                       key={link.href}
                       onClick={() => handleNavClick(link.href)}
-                      className="text-lg text-slate-600 hover:text-blue-600 transition-colors text-left"
+                      className="text-lg text-muted-foreground hover:text-primary transition-colors text-left"
                     >
                       {link.label}
                     </button>
                   ))}
-                  <div className="flex space-x-4 pt-6 border-t">
+                  <div className="flex justify-center">
+                    <ModeToggle />
+                  </div>
+                  <div className="flex space-x-4 pt-6 border-t border-border">
                     {socialLinks.map((social) => (
                       <a
                         key={social.label}
                         href={social.href}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="w-10 h-10 bg-slate-100 hover:bg-slate-200 rounded-full flex items-center justify-center transition-colors"
+                        className="w-10 h-10 bg-muted hover:bg-muted/80 rounded-full flex items-center justify-center transition-colors"
                         aria-label={social.label}
                       >
-                        <social.icon className="w-5 h-5 text-slate-600" />
+                        <social.icon className="w-5 h-5 text-muted-foreground" />
                       </a>
                     ))}
                   </div>

--- a/client/src/components/mode-toggle.tsx
+++ b/client/src/components/mode-toggle.tsx
@@ -1,0 +1,25 @@
+import { useState, useEffect } from "react";
+import { useTheme } from "next-themes";
+import { Sun, Moon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export function ModeToggle() {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) return null;
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+    >
+      <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+      <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+      <span className="sr-only">Toggle theme</span>
+    </Button>
+  );
+}

--- a/client/src/components/sections/biography.tsx
+++ b/client/src/components/sections/biography.tsx
@@ -2,14 +2,14 @@ import { profileData } from "@/data/content";
 
 export default function Biography() {
   return (
-    <section className="py-16 bg-slate-50">
+    <section className="py-16 bg-background">
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-12">
-          <h2 className="text-3xl lg:text-4xl font-bold text-slate-800 mb-8">
+          <h2 className="text-3xl lg:text-4xl font-bold text-foreground mb-8">
             Biography
           </h2>
         </div>
-        <div className="prose prose-lg mx-auto text-slate-600 leading-relaxed">
+        <div className="prose prose-lg mx-auto text-muted-foreground leading-relaxed">
           <p className="mb-6 text-lg">
             {profileData.biography.paragraph1}
           </p>

--- a/client/src/components/sections/blog.tsx
+++ b/client/src/components/sections/blog.tsx
@@ -11,23 +11,23 @@ export default function Blog() {
 
   if (isLoading) {
     return (
-      <section id="blog" className="py-16 bg-slate-50">
+      <section id="blog" className="py-16 bg-background">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-12">
-            <h2 className="text-3xl lg:text-4xl font-bold text-slate-800 mb-4">
+            <h2 className="text-3xl lg:text-4xl font-bold text-foreground mb-4">
               Blog
             </h2>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
             {[1, 2, 3].map((i) => (
-              <Card key={i} className="bg-white border-0">
+              <Card key={i} className="bg-card border-0">
                 <CardContent className="p-8">
                   <div className="animate-pulse">
-                    <div className="h-4 bg-slate-200 rounded mb-4"></div>
-                    <div className="h-6 bg-slate-200 rounded mb-4"></div>
-                    <div className="h-4 bg-slate-200 rounded mb-2"></div>
-                    <div className="h-4 bg-slate-200 rounded mb-6"></div>
-                    <div className="h-4 bg-slate-200 rounded w-24"></div>
+                    <div className="h-4 bg-muted rounded mb-4"></div>
+                    <div className="h-6 bg-muted rounded mb-4"></div>
+                    <div className="h-4 bg-muted rounded mb-2"></div>
+                    <div className="h-4 bg-muted rounded mb-6"></div>
+                    <div className="h-4 bg-muted rounded w-24"></div>
                   </div>
                 </CardContent>
               </Card>
@@ -39,35 +39,35 @@ export default function Blog() {
   }
 
   return (
-    <section id="blog" className="py-16 bg-slate-50">
+    <section id="blog" className="py-16 bg-background">
       <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-12">
-          <h2 className="text-3xl lg:text-4xl font-bold text-slate-800 mb-4">
+          <h2 className="text-3xl lg:text-4xl font-bold text-foreground mb-4">
             Blog
           </h2>
         </div>
         
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
           {recentPosts.map((post: any) => (
-            <Card key={post.slug} className="bg-white border-0 hover:shadow-lg transition-shadow">
+            <Card key={post.slug} className="bg-card border-0 hover:shadow-lg transition-shadow">
               <CardContent className="p-8">
-                <div className="flex items-center gap-2 text-sm text-slate-500 mb-4">
+                <div className="flex items-center gap-2 text-sm text-muted-foreground mb-4">
                   <span>{post.date}</span>
                 </div>
-                <h3 className="text-xl font-semibold text-slate-800 mb-4">
-                  <Link 
+                <h3 className="text-xl font-semibold text-foreground mb-4">
+                  <Link
                     href={`/blog/${post.slug}`}
-                    className="hover:text-blue-600 transition-colors"
+                    className="hover:text-primary transition-colors"
                   >
                     {post.title}
                   </Link>
                 </h3>
-                <p className="text-slate-600 leading-relaxed mb-6">
+                <p className="text-muted-foreground leading-relaxed mb-6">
                   {post.excerpt}
                 </p>
-                <Link 
+                <Link
                   href={`/blog/${post.slug}`}
-                  className="text-blue-600 hover:text-blue-700 font-medium"
+                  className="text-primary hover:text-primary/90 font-medium"
                 >
                   Read more →
                 </Link>

--- a/client/src/components/sections/contact.tsx
+++ b/client/src/components/sections/contact.tsx
@@ -8,32 +8,32 @@ export default function Contact() {
       title: "Email",
       value: contactInfo.email,
       href: `mailto:${contactInfo.email}`,
-      color: "text-blue-600",
-      bgColor: "bg-blue-100"
+      color: "text-blue-600 dark:text-blue-300",
+      bgColor: "bg-blue-100 dark:bg-blue-900",
     },
     {
       icon: Phone,
-      title: "Phone", 
+      title: "Phone",
       value: contactInfo.phone,
       href: `tel:+85266750566`,
-      color: "text-emerald-600",
-      bgColor: "bg-emerald-100"
+      color: "text-emerald-600 dark:text-emerald-300",
+      bgColor: "bg-emerald-100 dark:bg-emerald-900",
     },
     {
       icon: MapPin,
       title: "Address",
       value: contactInfo.location,
       href: null,
-      color: "text-slate-600",
-      bgColor: "bg-slate-100"
+      color: "text-muted-foreground",
+      bgColor: "bg-muted"
     }
   ];
 
   return (
-    <section id="contact" className="py-16 bg-white">
+    <section id="contact" className="py-16 bg-background">
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-12">
-          <h2 className="text-3xl lg:text-4xl font-bold text-slate-800 mb-4">
+          <h2 className="text-3xl lg:text-4xl font-bold text-foreground mb-4">
             Contacts
           </h2>
         </div>
@@ -44,18 +44,18 @@ export default function Contact() {
               <div className={`w-16 h-16 ${item.bgColor} rounded-full flex items-center justify-center mx-auto mb-4`}>
                 <item.icon className={`w-6 h-6 ${item.color}`} />
               </div>
-              <h3 className="text-lg font-semibold text-slate-800 mb-2">
+              <h3 className="text-lg font-semibold text-foreground mb-2">
                 {item.title}
               </h3>
               {item.href ? (
-                <a 
+                <a
                   href={item.href}
                   className={`${item.color} hover:opacity-70 transition-opacity`}
                 >
                   {item.value}
                 </a>
               ) : (
-                <span className="text-slate-600">{item.value}</span>
+                <span className="text-muted-foreground">{item.value}</span>
               )}
             </div>
           ))}

--- a/client/src/components/sections/hero.tsx
+++ b/client/src/components/sections/hero.tsx
@@ -21,21 +21,21 @@ export default function Hero() {
             />
           </div>
           <div className="flex-1 text-center lg:text-left">
-            <h1 className="text-4xl lg:text-5xl font-bold text-slate-800 mb-4">
+            <h1 className="text-4xl lg:text-5xl font-bold text-foreground mb-4">
               {profileData.name}
             </h1>
-            <p className="text-xl lg:text-2xl text-slate-600 mb-6">
+            <p className="text-xl lg:text-2xl text-muted-foreground mb-6">
               {profileData.title}
             </p>
-            <p className="text-lg lg:text-xl text-slate-700 mb-8 font-medium">
+            <p className="text-lg lg:text-xl text-foreground mb-8 font-medium">
               {profileData.tagline}
             </p>
-            <p className="text-base lg:text-lg text-slate-600 mb-8 leading-relaxed max-w-2xl">
+            <p className="text-base lg:text-lg text-muted-foreground mb-8 leading-relaxed max-w-2xl">
               {profileData.bio}
             </p>
-            <Button 
+            <Button
               onClick={handleContactClick}
-              className="bg-blue-600 hover:bg-blue-700 text-white px-8 py-3 text-lg font-medium shadow-lg"
+              className="px-8 py-3 text-lg font-medium shadow-lg"
             >
               Contacts
             </Button>

--- a/client/src/components/sections/projects.tsx
+++ b/client/src/components/sections/projects.tsx
@@ -5,24 +5,31 @@ import { projects } from "@/data/content";
 export default function Projects() {
   const getTagColor = (tag: string) => {
     const colors = {
-      blockchain: "bg-blue-100 text-blue-700",
-      ticketing: "bg-emerald-100 text-emerald-700", 
-      Database: "bg-slate-100 text-slate-700",
-      testing: "bg-slate-100 text-slate-700"
+      blockchain:
+        "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-100",
+      ticketing:
+        "bg-emerald-100 text-emerald-700 dark:bg-emerald-900 dark:text-emerald-100",
+      Database:
+        "bg-slate-100 text-slate-700 dark:bg-slate-900 dark:text-slate-300",
+      testing:
+        "bg-slate-100 text-slate-700 dark:bg-slate-900 dark:text-slate-300",
     };
-    return colors[tag as keyof typeof colors] || "bg-gray-100 text-gray-700";
+    return (
+      colors[tag as keyof typeof colors] ||
+      "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300"
+    );
   };
 
   return (
-    <section id="projects" className="py-16 bg-white">
+    <section id="projects" className="py-16 bg-background">
       <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center mb-12">
-          <h2 className="text-3xl lg:text-4xl font-bold text-slate-800">
+          <h2 className="text-3xl lg:text-4xl font-bold text-foreground">
             Projects
           </h2>
-          <a 
-            href="#projects" 
-            className="text-blue-600 hover:text-blue-700 font-medium"
+          <a
+            href="#projects"
+            className="text-primary hover:text-primary/90 font-medium"
           >
             Go to projects →
           </a>
@@ -30,7 +37,7 @@ export default function Projects() {
         
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
           {projects.map((project) => (
-            <Card key={project.id} className="bg-slate-50 border-0 overflow-hidden hover:shadow-xl transition-shadow">
+            <Card key={project.id} className="bg-card border-0 overflow-hidden hover:shadow-xl transition-shadow">
               <img 
                 src={project.image}
                 alt={project.title}
@@ -39,8 +46,8 @@ export default function Projects() {
               <CardContent className="p-8">
                 <div className="flex gap-2 mb-4">
                   {project.tags.map((tag) => (
-                    <Badge 
-                      key={tag} 
+                    <Badge
+                      key={tag}
                       variant="secondary"
                       className={`${getTagColor(tag)} hover:${getTagColor(tag)}`}
                     >
@@ -48,10 +55,10 @@ export default function Projects() {
                     </Badge>
                   ))}
                 </div>
-                <h3 className="text-xl font-semibold text-slate-800 mb-3">
+                <h3 className="text-xl font-semibold text-foreground mb-3">
                   {project.title}
                 </h3>
-                <p className="text-slate-600 leading-relaxed">
+                <p className="text-muted-foreground leading-relaxed">
                   {project.description}
                 </p>
               </CardContent>

--- a/client/src/components/sections/skills.tsx
+++ b/client/src/components/sections/skills.tsx
@@ -3,22 +3,22 @@ import { skillCategories } from "@/data/content";
 
 export default function Skills() {
   return (
-    <section id="skills" className="py-16 bg-white">
+    <section id="skills" className="py-16 bg-background">
       <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-12">
-          <h2 className="text-3xl lg:text-4xl font-bold text-slate-800 mb-4">
+          <h2 className="text-3xl lg:text-4xl font-bold text-foreground mb-4">
             My superpowers
           </h2>
         </div>
         
         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
           {skillCategories.map((category, index) => (
-            <Card key={index} className="bg-slate-50 border-0 hover:shadow-lg transition-shadow">
+            <Card key={index} className="bg-card border-0 hover:shadow-lg transition-shadow">
               <CardContent className="p-8">
-                <h3 className="text-xl font-semibold text-slate-800 mb-4">
+                <h3 className="text-xl font-semibold text-foreground mb-4">
                   {category.title}
                 </h3>
-                <p className="text-slate-600">
+                <p className="text-muted-foreground">
                   {category.skills}
                 </p>
               </CardContent>

--- a/client/src/components/theme-provider.tsx
+++ b/client/src/components/theme-provider.tsx
@@ -1,0 +1,6 @@
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import type { ThemeProviderProps } from "next-themes";
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+}

--- a/client/src/pages/blog-post.tsx
+++ b/client/src/pages/blog-post.tsx
@@ -18,21 +18,21 @@ export default function BlogPost() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-slate-50">
+      <div className="min-h-screen bg-background">
         <Navigation />
         <main className="py-16">
           <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
             <div className="animate-pulse">
-              <div className="h-10 bg-slate-200 rounded mb-6 w-32"></div>
-              <div className="h-4 bg-slate-200 rounded mb-4 w-24"></div>
-              <div className="h-12 bg-slate-200 rounded mb-6"></div>
-              <div className="h-6 bg-slate-200 rounded mb-8"></div>
+              <div className="h-10 bg-muted rounded mb-6 w-32"></div>
+              <div className="h-4 bg-muted rounded mb-4 w-24"></div>
+              <div className="h-12 bg-muted rounded mb-6"></div>
+              <div className="h-6 bg-muted rounded mb-8"></div>
               <Card>
                 <CardContent className="p-8">
                   <div className="space-y-4">
-                    <div className="h-4 bg-slate-200 rounded"></div>
-                    <div className="h-4 bg-slate-200 rounded"></div>
-                    <div className="h-4 bg-slate-200 rounded w-3/4"></div>
+                    <div className="h-4 bg-muted rounded"></div>
+                    <div className="h-4 bg-muted rounded"></div>
+                    <div className="h-4 bg-muted rounded w-3/4"></div>
                   </div>
                 </CardContent>
               </Card>
@@ -46,16 +46,16 @@ export default function BlogPost() {
 
   if (!post) {
     return (
-      <div className="min-h-screen bg-slate-50">
+      <div className="min-h-screen bg-background">
         <Navigation />
         <main className="py-16">
           <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
             <Card>
               <CardContent className="p-8 text-center">
-                <h1 className="text-2xl font-bold text-slate-800 mb-4">
+                <h1 className="text-2xl font-bold text-foreground mb-4">
                   Blog post not found
                 </h1>
-                <p className="text-slate-600 mb-6">
+                <p className="text-muted-foreground mb-6">
                   The blog post you're looking for doesn't exist.
                 </p>
                 <Link href="/">
@@ -74,7 +74,7 @@ export default function BlogPost() {
   }
 
   return (
-    <div className="min-h-screen bg-slate-50">
+    <div className="min-h-screen bg-background">
       <Navigation />
       <main className="py-16">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -86,16 +86,16 @@ export default function BlogPost() {
               </Button>
             </Link>
             
-            <div className="flex items-center gap-2 text-slate-500 mb-4">
+            <div className="flex items-center gap-2 text-muted-foreground mb-4">
               <Calendar className="w-4 h-4" />
               <span>{post.date}</span>
             </div>
             
-            <h1 className="text-4xl lg:text-5xl font-bold text-slate-800 mb-6">
+            <h1 className="text-4xl lg:text-5xl font-bold text-foreground mb-6">
               {post.title}
             </h1>
             
-            <p className="text-xl text-slate-600 leading-relaxed">
+            <p className="text-xl text-muted-foreground leading-relaxed">
               {post.excerpt}
             </p>
           </div>
@@ -107,13 +107,13 @@ export default function BlogPost() {
                 dangerouslySetInnerHTML={{
                   __html: post.content.replace(/\n/g, '<br>').replace(/#{1,3}\s/g, (match: string) => {
                     const level = match.trim().length;
-                    return level === 1 ? '<h1 class="text-3xl font-semibold mt-8 mb-4 text-slate-800">' :
-                           level === 2 ? '<h2 class="text-2xl font-semibold mt-6 mb-3 text-slate-800">' :
-                           '<h3 class="text-xl font-semibold mt-4 mb-2 text-slate-800">';
+                    return level === 1 ? '<h1 class="text-3xl font-semibold mt-8 mb-4 text-foreground">' :
+                           level === 2 ? '<h2 class="text-2xl font-semibold mt-6 mb-3 text-foreground">' :
+                           '<h3 class="text-xl font-semibold mt-4 mb-2 text-foreground">';
                   }).replace(/```[\s\S]*?```/g, (match: string) => {
                     const code = match.slice(3, -3);
-                    return `<pre class="bg-slate-100 p-4 rounded-lg overflow-x-auto my-4"><code>${code}</code></pre>`;
-                  }).replace(/`([^`]+)`/g, '<code class="bg-slate-100 px-2 py-1 rounded text-sm">$1</code>')
+                    return `<pre class="bg-muted p-4 rounded-lg overflow-x-auto my-4"><code>${code}</code></pre>`;
+                  }).replace(/`([^`]+)`/g, '<code class="bg-muted px-2 py-1 rounded text-sm">$1</code>')
                     .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
                     .replace(/\*([^*]+)\*/g, '<em>$1</em>')
                     .replace(/^\d+\.\s/gm, '<li>')

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -9,7 +9,7 @@ import Contact from "@/components/sections/contact";
 
 export default function Home() {
   return (
-    <div className="min-h-screen bg-slate-50">
+    <div className="min-h-screen bg-background">
       <Navigation />
       <main>
         <Hero />

--- a/client/src/pages/not-found.tsx
+++ b/client/src/pages/not-found.tsx
@@ -3,15 +3,15 @@ import { AlertCircle } from "lucide-react";
 
 export default function NotFound() {
   return (
-    <div className="min-h-screen w-full flex items-center justify-center bg-gray-50">
+    <div className="min-h-screen w-full flex items-center justify-center bg-background">
       <Card className="w-full max-w-md mx-4">
         <CardContent className="pt-6">
           <div className="flex mb-4 gap-2">
             <AlertCircle className="h-8 w-8 text-red-500" />
-            <h1 className="text-2xl font-bold text-gray-900">404 Page Not Found</h1>
+            <h1 className="text-2xl font-bold text-foreground">404 Page Not Found</h1>
           </div>
 
-          <p className="mt-4 text-sm text-gray-600">
+          <p className="mt-4 text-sm text-muted-foreground">
             Did you forget to add the page to the router?
           </p>
         </CardContent>


### PR DESCRIPTION
## Summary
- add theme provider and mode toggle for switching light/dark modes
- update navigation and pages to use theme-aware colors
- adjust project and contact sections for dark mode styling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab2ed7e338832a8c41ebd7df7d56aa