### PR TITLE
docs: add AGENTS.md with cloud agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Services
+
+| Service | Command | Port | Notes |
+|---------|---------|------|-------|
+| Vite Dev Server | `npm run dev` | 5173 | Frontend-only app; no backend/DB required |
+
+### Quick reference
+
+- **Install deps**: `npm install`
+- **Type check**: `npm run check`
+- **Build**: `npm run build`
+- **Dev server**: `npm run dev` (serves on port 5173, not 5000 despite what CLAUDE.md says)
+
+### Gotchas
+
+- The Vite config does not set a custom port; the dev server runs on the default **5173**, not port 5000 as CLAUDE.md states.
+- No database is required to run the app. The `DATABASE_URL` env var is only needed for `npm run db:push` (schema migration to Neon Postgres). The app falls back to in-memory storage.
+- `gatsby` and several unused backend packages (express, passport, etc.) are listed in `package.json` dependencies but are not actively used. They inflate install time (~70s) but do not affect the running app.
+- There is no ESLint config or lint script; type checking via `npm run check` (tsc) is the primary static analysis step.
+- The `@replit/vite-plugin-cartographer` plugin only loads when `REPL_ID` is set; safe to ignore outside Replit.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud specific instructions for future agents, including:

- Service table (Vite dev server on port 5173)
- Quick reference commands for install, type check, build, and dev server
- Non-obvious gotchas: actual dev port (5173 vs documented 5000), no database required, unused deps, no lint config

**Environment verified working:**
- `npm install` completes successfully
- `npm run check` (TypeScript) passes
- `npm run build` (production build) succeeds
- `npm run dev` serves the portfolio app on port 5173

<a href="https://cursor.com/agents/bc-fc50a5b9-c2dc-4315-8244-95f41c449051/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fportfolio_app_demo.mp4"><img src="https://cursor.com/artifacts/c/art-767ef725-f7fd-43ad-a4ba-9f37bc78b539" alt="portfolio_app_demo.mp4" /></a>

![Portfolio hero section](https://cursor.com/artifacts/c/art-ebc144cb-24d6-4327-bc07-c1ed854e80c2)
![Blog post page](https://cursor.com/artifacts/c/art-4dc27571-b7fb-4a26-94df-71e59f939efb)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc50a5b9-c2dc-4315-8244-95f41c449051"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc50a5b9-c2dc-4315-8244-95f41c449051"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

